### PR TITLE
Add keymaps supplied in issues

### DIFF
--- a/keymaps/ca_FR.map
+++ b/keymaps/ca_FR.map
@@ -1,0 +1,106 @@
+<Esc>
+1 ! ±
+2 " @
+3 / £
+4 $ ¢
+5 % ¤
+6 ? ¬
+7 & ¦
+8 * ²
+9 ( ³
+0 ) ¼
+- _ ½
+= + ¾
+<BckSp>
+<Tab>
+q Q
+w W
+e E
+r R
+t T
+y Y
+u U
+i I
+o O §
+p P ¶
+^ ^ [
+¸ ¨ ]
+<Enter>
+<LCtrl>
+a A
+s S
+d D
+f F
+g G
+h H
+j J
+k K
+l L
+; : ~
+` ` {
+# | \
+<LShft>
+< > }
+z Z
+x X
+c C
+v V
+b B
+n N
+m M µ
+, ' ¯
+. .­
+é É
+<RShft>
+<CpsLk>
+<LAlt>
+ 
+<CpsLk>
+<F1>
+<F2>
+<F3>
+<F4>
+<F5>
+<F6>
+<F7>
+<F8>
+<F9>
+<F10>
+<NumLk>
+<ScrLk>
+<KP7>
+<KP8>
+<KP9>
+<KP->
+<KP4>
+<KP5>
+<KP6>
+<KP+>
+<KP1>
+<KP2>
+<KP3>
+<KP0>
+<KP.>
+Ĉ
+<F11>
+<F12>
+<KPEnt>
+<RCtrl>
+<KP/>
+<PrtSc>
+<AltGr>
+<Break>
+<Home>
+<Up>
+<PgUp>
+<Left>
+<Right>
+<End>
+<Down>
+<PgDn>
+<Ins>
+<Del>
+<Pause>
+<LMeta>
+<RMeta>
+<Menu>

--- a/keymaps/de_CH.map
+++ b/keymaps/de_CH.map
@@ -1,0 +1,106 @@
+<Esc>
+1 + |
+2 " @
+3 * #
+4 ç ¼
+5 % ½
+6 & ¬
+7 / |
+8 ( ¢
+9 ) ]
+0 = }
+' ? '
+^ ` ~
+<BckSp>
+<Tab>
+q Q @
+w W ł
+e E €
+r R ¶
+t T ŧ
+z Z ←
+u U ↓
+i I →
+o O ø
+p P þ
+ü è [
+" ! ]
+<Enter>
+<Lctrl>
+a A æ
+s S ß
+d D ð
+f F đ
+g G ŋ
+h H ħ
+j J j
+k K ĸ
+l L ł
+ö é '
+ä à {
+§ ° ¬
+<LShft>
+$ £ }
+y Y «
+x X »
+c C ¢
+v V “
+b B ”
+n N n
+m M µ
+, ;
+. : ·
+- _
+<RShft>
+<KP*>
+<LAlt>
+ 
+<CpsLk>
+<F1>
+<F2>
+<F3>
+<F4>
+<F5>
+<F6>
+<F7>
+<F8>
+<F9>
+<F10>
+<NumLk>
+<ScrLk>
+<KP7>
+<KP8>
+<KP9>
+<KP->
+<KP4>
+<KP5>
+<KP6>
+<KP+>
+<KP1>
+<KP2>
+<KP3>
+<KP0>
+<KP.>
+< > \
+<F11>
+<F12>
+<KPEnt>
+<RCtrl>
+<KP/>
+<PrtSc>
+<AltGr>
+<Break>
+<Home>
+<Up>
+<PgUp>
+<Left>
+<Right>
+<End>
+<Down>
+<PgDn>
+<Ins>
+<Del>
+<Pause>
+<LMeta>
+<RMeta>
+<Menu>

--- a/keymaps/en_US_ubuntu_1204.map
+++ b/keymaps/en_US_ubuntu_1204.map
@@ -1,0 +1,106 @@
+<Esc>
+1 ! 1
+2 @
+3 #
+4 $
+5 %
+6 ^
+7 &
+8 *
+9 ( 9
+0 ) 0
+- _
+= + =
+<BckSp>
+<Tab>
+q Q
+w W
+e E
+r R
+t T
+y Y
+u U
+i I
+o O
+p P
+[ {
+] }
+<Enter>
+<LCtrl>
+a A
+s S
+d D
+f F
+g G
+h H
+j J
+k K
+l L
+; : ;
+' " '
+` ~ `
+<LShft>
+\ |
+z Z
+x X
+c C
+v V
+b B
+n N
+m M
+, < ,
+. > .
+/ ? /
+<RShft>
+<CpsLk>
+<LAlt>
+ 
+<CpsLk>
+<F1>
+<F2>
+<F3>
+<F4>
+<F5>
+<F6>
+<F7>
+<F8>
+<F9>
+<F10>
+<NumLk>
+<ScrLk>
+<KP7>
+<KP8>
+<KP9>
+<KP->
+<KP4>
+<KP5>
+<KP6>
+<KP+>
+<KP1>
+<KP2>
+<KP3>
+<KP0>
+<KP.>
+Ĉ
+<F11>
+<F12>
+<KPEnt>
+<RCtrl>
+<KP/>
+<PrtSc>
+<AltGr>
+<Break>
+<Home>
+<Up>
+<PgUp>
+<Left>
+<Right>
+<End>
+<Down>
+<PgDn>
+<Ins>
+<Del>
+<Pause>
+<LMeta>
+<RMeta>
+<Menu>

--- a/keymaps/pl.map
+++ b/keymaps/pl.map
@@ -1,0 +1,106 @@
+<Esc>
+1 ! ¹
+2 @ ²
+3 # ³
+4 $ ¼
+5 % ½
+6 ^ ¾
+7 & {
+8 * [
+9 ( ]
+0 ) }
+- _ \
+= + ¸
+<BckSp>
+<Tab>
+q Q @
+w W ł
+e E ę
+r R ¶
+t T ŧ
+y Y ←
+u U ↓
+i I →
+o O ó
+p P þ
+[ { ¨
+] } ~
+<Enter>
+<LCtrl>
+a A ą
+s S ś
+d D ð
+f F đ
+g G ŋ
+h H ħ
+j J j
+k K ĸ
+l L ł
+; : ´
+' " ^
+` ~ ¬
+<LShft>
+\ | `
+z Z ż
+x X ź
+c C ć
+v V “
+b B ”
+n N ń
+m M µ
+, <
+. > ·
+/ ?
+<RShft>
+<KP*>
+<LAlt>
+ 
+<CpsLk>
+<F1>
+<F2>
+<F3>
+<F4>
+<F5>
+<F6>
+<F7>
+<F8>
+<F9>
+<F10>
+<NumLk>
+<ScrLk>
+<KP7>
+<KP8>
+<KP9>
+<KP->
+<KP4>
+<KP5>
+<KP6>
+<KP+>
+<KP1>
+<KP2>
+<KP3>
+<KP0>
+<KP.>
+Ą
+<F11>
+<F12>
+<KPEnt>
+<RCtrl>
+<KP/>
+<PrtSc>
+<AltGr>
+<Break>
+<Home>
+<Up>
+<PgUp>
+<Left>
+<Right>
+<End>
+<Down>
+<PgDn>
+<Ins>
+<Del>
+<Pause>
+<LMeta>
+<RMeta>
+<Menu>


### PR DESCRIPTION
https://github.com/kernc/logkeys/issues/88 - Ubuntu 12.04 en US
https://github.com/kernc/logkeys/issues/119 - French Canadian
https://github.com/kernc/logkeys/issues/121 - Swiss German
https://github.com/kernc/logkeys/issues/123 - Polish

There are a few Arabic maps that I didn't include.

I haven't tested these maps myself, I'm not able to - I'd like to add a sanity check/smoke test that parses the keymaps to ensure that there are no parsing errors, at least.

If we merge this, we can close the above issues.