### PR TITLE
Added option to print to standard output

### DIFF
--- a/man/logkeys.8
+++ b/man/logkeys.8
@@ -49,6 +49,8 @@ Set ouput log file to \fIlogfile\fR. If no \fB-o\fR option is provided, logkeys
 appends to \fI/var/log/logkeys.log\fR file. If \fIlogfile\fR doesn't exist, logkeys
 creates the file with 600 permissions.
 .IP
+To print output to standard output, use '-' as logfile: \fB-o\fR \fI-\fR.
+.IP
 See also \fBLOGFILE FORMAT\fR section.
 
 .TP

--- a/src/usage.cc
+++ b/src/usage.cc
@@ -19,7 +19,7 @@ void usage()
 "\n"
 "  -s, --start               start logging keypresses\n"
 "  -m, --keymap=FILE         use keymap FILE\n"
-"  -o, --output=FILE         log output to FILE [" DEFAULT_LOG_FILE "]\n"
+"  -o, --output=FILE         log output to FILE [" DEFAULT_LOG_FILE "] or standard output '-'\n"
 "  -u, --us-keymap           use en_US keymap instead of configured default\n"
 "  -k, --kill                kill running logkeys process\n"
 "  -d, --device=FILE         input event device [eventX from " INPUT_EVENT_PATH "]\n"


### PR DESCRIPTION
This commit adds the ability to print to standard output instead to a log file. Using:
`logkeys --start -o -`

