### PR TITLE
getopt API uses int as return value, bugfix.

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -59,7 +59,7 @@ void process_command_line_arguments(int argc, char **argv)
     {0}
   };
   
-  char c;
+  int c;
   int option_index;
   
   while ((c = getopt_long(argc, argv, "sm:o:ukd:?", long_options, &option_index)) != -1)


### PR DESCRIPTION
Changed type of variable that gets the return value from getopt_long from char to int.
The char type produced a bug when compiled to (at least one type of) arm processor, where char was defined as an unsigned int and the return value of -1 was converted as 255. This bug resulted in always returning showing the usage and exit with error.