### PR TITLE
Fix --output flag and FLAG_TIMESTAMP_EVERY value

### DIFF
--- a/src/args.cc
+++ b/src/args.cc
@@ -35,7 +35,7 @@ struct arguments
 #define FLAG_POST_IRC        0x10  // post log to remote IRC server, --post-irc switch
 #define FLAG_POST_SIZE       0x20  // post log to remote HTTP or IRC server when log of size optarg, --post-size
 #define FLAG_NO_DAEMON       0x40  // don't daemonize process, stay in foreground, --no-daemon switch
-#define FLAG_TIMESTAMP_EVERY 0x40  // log timestamps on every key, --timestamp-every switch
+#define FLAG_TIMESTAMP_EVERY 0x80  // log timestamps on every key, --timestamp-every switch
 } args = {0};  // default all args to 0x0 or ""
 
 

--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -701,8 +701,9 @@ int main(int argc, char **argv)
     error(EXIT_FAILURE, errno, "Another process already running? Quitting. (" PID_FILE ")");
 
   if (!(args.flags & FLAG_NO_DAEMON)) {
+    int nochdir = 1;  // don't change cwd to root (allow relative output file paths)
     int noclose = 1;  // don't close streams (stderr used)
-    if (daemon(0, noclose) == -1)  // become daemon
+    if (daemon(nochdir, noclose) == -1)  // become daemon
       error(EXIT_FAILURE, errno, "Failed to become daemon");
   }
 


### PR DESCRIPTION
First of all, change FLAG_TIMSTAMP_EVERY to not have the same value as FLAG_NO_DAEMON (I botched a merge conflict, my bad!)

Then, call daemon(3) with nochdir = 1 so that the daemon will maintain the PWD from which it started, and as a result the log file specified with the --output flag will be relative to that directory. Fixes #205 