### PR TITLE
Updated determine_device_input() strategy

### DIFF
--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -349,7 +349,7 @@ void determine_input_device()
   //Check for all devices with keymask ending with 'e' (means, they have Esc, KEY_1, KEY_2, so probably keyboard
   //Take the Name, Handlers, and KEY values
   const char* cmd = EXE_GREP " -B8 -E 'KEY=.*e$' /proc/bus/input/devices | "
-    EXE_GREP " -E 'Handlers|Name|KEY' ";
+    EXE_GREP " -E 'Name|Handlers|KEY' ";
   std::stringstream output(execute(cmd));
   
   std::vector<std::string> devices;

--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -402,7 +402,7 @@ void determine_input_device()
   }
 
   //Choose device with the best score
-  int max_device = std::max_element(devices.begin(), devices.end()) - devices.begin();
+  int max_device = std::max_element(scores.begin(), scores.end()) - scores.begin();
   args.device = devices[max_device];  // for now, use only the first found device
   
   // now we reclaim those root privileges
@@ -757,4 +757,3 @@ int main(int argc, char** argv)
 {
   return logkeys::main(argc, argv);
 }
-

--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -346,7 +346,10 @@ void determine_input_device()
   // better be safe than sory: while running other programs, switch user to nobody
   setegid(65534); seteuid(65534);
   
-  //Check for all devices with keymask ending with 'e' (means, they have Esc, KEY_1, KEY_2, so probably keyboard
+  //Look for devices with keybit bitmask that has keys a keyboard doeas
+  //If a bitmask ends with 'e', it supports KEY_2, KEY_1, KEY_ESC, and KEY_RESERVED is set to 0, so it's probably a keyboard
+  //keybit:   https://github.com/torvalds/linux/blob/02de58b24d2e1b2cf947d57205bd2221d897193c/include/linux/input.h#L45
+  //keycodes: https://github.com/torvalds/linux/blob/139711f033f636cc78b6aaf7363252241b9698ef/include/uapi/linux/input-event-codes.h#L75
   //Take the Name, Handlers, and KEY values
   const char* cmd = EXE_GREP " -B8 -E 'KEY=.*e$' /proc/bus/input/devices | "
     EXE_GREP " -E 'Name|Handlers|KEY' ";


### PR DESCRIPTION
determine_device_input() now matches devices that have a key bitmask ending with 'e'. Ranks devices based on key bitmask size and if name contains 'keyboard'. Returns highest scored device.

This should help with device resolution greatly. Looks like it
resolves #222,
resolves #215, 
resolves #212, 
resolves #192, 
resolves #160, 
resolves #159, 
resolves #154.
resolves https://github.com/kernc/logkeys/issues/224
