### PR TITLE
Fix overflow

### DIFF
--- a/src/keytables.cc
+++ b/src/keytables.cc
@@ -40,19 +40,19 @@ const char char_or_func[] =  // c = character key, f = function key, _ = blank/e
 
 inline bool is_char_key(unsigned int code)
 {
-  assert(code < sizeof(char_or_func));
+  assert(code < sizeof(char_or_func)-1);
   return (char_or_func[code] == 'c');
 }
 
 inline bool is_func_key(unsigned int code)
 {
-  assert(code < sizeof(char_or_func));
+  assert(code < sizeof(char_or_func)-1);
   return (char_or_func[code] == 'f');
 }
 
 inline bool is_used_key(unsigned int code)
 {
-  assert(code < sizeof(char_or_func));
+  assert(code < sizeof(char_or_func)-1);
   return (char_or_func[code] != '_');
 }
 

--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -189,7 +189,7 @@ void determine_system_keymap()
   std::stringstream ss, dump(execute(COMMAND_STR_DUMPKEYS));  // see example output after i.e. `loadkeys slovene`
   std::string line;
 
-  unsigned int i = 0;   // keycode
+  unsigned int i = -1;   // keycode
   int index;
   int utf8code;      // utf-8 code of keysym answering keycode i
   
@@ -205,7 +205,7 @@ void determine_system_keymap()
       index = line.find("U+", index);
     }
     
-    if (++i >= sizeof(char_or_func)) break;  // only ever map keycodes up to 128 (currently N_KEYS_DEFINED are used)
+    if (++i >= sizeof(char_or_func)-1) break;  // only ever map keycodes up to 128 (currently N_KEYS_DEFINED are used)
     if (!is_char_key(i)) continue;  // only map character keys of keyboard
     
     assert(line.size() > 0);


### PR DESCRIPTION
I believe this fixes issue #239, where `args.flags` was getting clobbered by an overflow

The problem was that sizeof(char_or_func) is 129, not 128, due to the trailing null byte.

However, I've tested logkeys on two computers, and on both I have unrelated keymap issues. Could someone please make sure this isn't breaking anything horribly before merging it? (ex. that I'm not chopping off a key?)