### PR TITLE
Add --no-bookends option

### DIFF
--- a/man/logkeys.8
+++ b/man/logkeys.8
@@ -4,7 +4,7 @@ logkeys \- a GNU/Linux keylogger that works!
 .SH SYNOPSIS
 .B logkeys \fB-s\fR [\fB-m \fIkeymap\fR | \fB-u\fR] [\fB-o \fIlogfile\fR] [\fB-d \fIdevice\fR]
 .br
-           [\fB--no-func-keys\fR] [\fB--no-timestamps\fR] 
+           [\fB--no-func-keys\fR] [\fB--no-timestamps\fR] [\fB--no-bookends\fR] 
 .br
            [\fB--post-http=\fIURL\fR] [\fB--post-size=\fISIZE\fR]
 .br
@@ -105,6 +105,10 @@ logged, influenced by Shift and AltGr modifiers.
 \fB-\-no-timestamps\fR
 When this option is set, logkeys doesn't prepend timestamp to each line of log file.
 Timestamps are only logged when logkeys starts and stops.
+
+.TP
+\fB-\-no-bookends\fR
+When this option is set, logkeys doesn't log messages when starting and stopping.
 
 .TP
 \fB-\-post-size=\fISIZE\fR

--- a/src/args.cc
+++ b/src/args.cc
@@ -28,14 +28,15 @@ struct arguments
   std::string irc_port;     // if --post-irc effective, this holds the IRC port number
   off_t post_size;     // post log file to remote when of size post_size, --post-size switch
   int flags;           // holds the following option flags
-#define FLAG_EXPORT_KEYMAP    0x1  // export keymap obtained from dumpkeys, --export-keymap is used
-#define FLAG_NO_FUNC_KEYS     0x2  // only log character keys (e.g. 'c', '2', etc.) and don't log function keys (e.g. <LShift>, etc.), --no-func-keys switch
-#define FLAG_NO_TIMESTAMPS    0x4  // don't log timestamps, --no-timestamps switch
-#define FLAG_POST_HTTP        0x8  // post log to remote HTTP server, --post-http switch
-#define FLAG_POST_IRC        0x10  // post log to remote IRC server, --post-irc switch
-#define FLAG_POST_SIZE       0x20  // post log to remote HTTP or IRC server when log of size optarg, --post-size
-#define FLAG_NO_DAEMON       0x40  // don't daemonize process, stay in foreground, --no-daemon switch
-#define FLAG_TIMESTAMP_EVERY 0x80  // log timestamps on every key, --timestamp-every switch
+#define FLAG_EXPORT_KEYMAP     0x1  // export keymap obtained from dumpkeys, --export-keymap is used
+#define FLAG_NO_FUNC_KEYS      0x2  // only log character keys (e.g. 'c', '2', etc.) and don't log function keys (e.g. <LShift>, etc.), --no-func-keys switch
+#define FLAG_NO_TIMESTAMPS     0x4  // don't log timestamps, --no-timestamps switch
+#define FLAG_POST_HTTP         0x8  // post log to remote HTTP server, --post-http switch
+#define FLAG_POST_IRC         0x10  // post log to remote IRC server, --post-irc switch
+#define FLAG_POST_SIZE        0x20  // post log to remote HTTP or IRC server when log of size optarg, --post-size
+#define FLAG_NO_DAEMON        0x40  // don't daemonize process, stay in foreground, --no-daemon switch
+#define FLAG_TIMESTAMP_EVERY  0x80  // log timestamps on every key, --timestamp-every switch
+#define FLAG_NO_BOOKENDS     0x100 // don't log "Staring logging..." and "Stopping logging..." messages
 } args = {0};  // default all args to 0x0 or ""
 
 
@@ -52,6 +53,7 @@ void process_command_line_arguments(int argc, char **argv)
     {"device",    required_argument, 0, 'd'},
     {"help",      no_argument,       0, '?'},
     {"export-keymap", required_argument, &flags, FLAG_EXPORT_KEYMAP},
+    {"no-bookends",   no_argument,       &flags, FLAG_NO_BOOKENDS},
     {"no-func-keys",  no_argument,       &flags, FLAG_NO_FUNC_KEYS},
     {"no-timestamps", no_argument,       &flags, FLAG_NO_TIMESTAMPS},
     {"post-http",     required_argument, &flags, FLAG_POST_HTTP},

--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -628,10 +628,12 @@ void log_loop()
   time(&cur_time);
   strftime(timestamp, sizeof(timestamp), TIME_FORMAT, localtime(&cur_time));
 
-  if (args.flags & FLAG_NO_TIMESTAMPS)
-    file_size += fprintf(out, "Logging started at %s\n\n", timestamp);
-  else
-    file_size += fprintf(out, "Logging started ...\n\n%s", timestamp);
+  if (!(args.flags & FLAG_NO_BOOKENDS)) {
+    if (args.flags & FLAG_NO_TIMESTAMPS)
+      file_size += fprintf(out, "Logging started at %s\n\n", timestamp);
+    else
+      file_size += fprintf(out, "Logging started ...\n\n%s", timestamp);
+  }
   fflush(out);
 
   // infinite loop: exit gracefully by receiving SIGHUP, SIGINT or SIGTERM (of which handler closes input_fd)
@@ -647,9 +649,11 @@ void log_loop()
   }
 
   // append final timestamp, close files and exit
-  time(&cur_time);
-  strftime(timestamp, sizeof(timestamp), "%F %T%z", localtime(&cur_time));
-  fprintf(out, "\n\nLogging stopped at %s\n\n", timestamp);
+  if (!(args.flags & FLAG_NO_BOOKENDS)) {
+    time(&cur_time);
+    strftime(timestamp, sizeof(timestamp), "%F %T%z", localtime(&cur_time));
+    fprintf(out, "\n\nLogging stopped at %s\n\n", timestamp);
+  }
   fclose(out);
 }
 


### PR DESCRIPTION
Removes the `Logging started...` and `Logging stopped at 2022-08-03 20:06:36+0100` messages. Indepdendent of `--no-timestamps`.

Closes #240

Open to suggestions on a better option name if you have one.