### PR TITLE
Actually parse keycodes instead of assuming they're all present in order

### DIFF
--- a/src/logkeys.cc
+++ b/src/logkeys.cc
@@ -202,7 +202,7 @@ void determine_system_keymap()
   int utf8code;      // utf-8 code of keysym answering keycode i
   
   while (std::getline(dump, line)) {
-    unsigned int keycode;
+    int keycode;
     ss.clear();
     ss.str("");
     utf8code = 0;


### PR DESCRIPTION
Some keyboards weren't being mapped correctly. It was due to parsing `dumpkeys` incorrectly

Fixes the other half of #162 and #245, along with PR https://github.com/kernc/logkeys/pull/246